### PR TITLE
Add `title` on the graph action elements for better a11y and user understanding

### DIFF
--- a/packages/starlight-site-graph/components/graph/action-element.ts
+++ b/packages/starlight-site-graph/components/graph/action-element.ts
@@ -22,6 +22,7 @@ export function renderActionContainer(context: GraphComponent) {
 
 		if (action === 'fullscreen') {
 			actionElement.innerHTML = context.isFullscreen ? icons.minimize : icons.maximize;
+			actionElement.ariaLabel = context.isFullscreen ? 'Minimize' : 'Maximize';
 			actionElement.onclick = e => {
 				context.isFullscreen ? context.disableFullscreen() : context.enableFullscreen();
 				e.stopPropagation();
@@ -34,6 +35,7 @@ export function renderActionContainer(context: GraphComponent) {
 			};
 		} else if (action === 'depth') {
 			actionElement.innerHTML = icons[('graph' + context.config.depth) as keyof typeof icons];
+			actionElement.ariaLabel = `Depth: ${context.config.depth}`;
 			actionElement.onclick = e => {
 				context.config.depth = (context.config.depth + 1) % MAX_DEPTH;
 				context.setup();
@@ -65,12 +67,14 @@ export function renderActionContainer(context: GraphComponent) {
 			};
 		} else if (action === 'reset-zoom') {
 			actionElement.innerHTML = icons.focus;
+			actionElement.ariaLabel = 'Reset Zoom';
 			actionElement.onclick = e => {
 				context.simulator.resetZoom();
 				e.stopPropagation();
 			};
 		} else if (action === 'render-arrows') {
 			actionElement.innerHTML = context.config.renderArrows ? icons.arrow : icons.line;
+			actionElement.ariaLabel = context.config.renderArrows ? 'Render Arrows' : 'Render Lines';
 			actionElement.onclick = e => {
 				context.config.renderArrows = !context.config.renderArrows;
 				context.simulator.requestRender = true;
@@ -85,6 +89,7 @@ export function renderActionContainer(context: GraphComponent) {
 			};
 		} else if (action === "settings") {
 			actionElement.innerHTML = icons.settings;
+			actionElement.ariaLabel = 'Show Settings';
 			actionElement.onclick = (_) => {
 				const chargeForceSlider = createValueSlider('Repel Force', context.config.repelForce, CHARGE_FORCE_SLIDER_MIN, CHARGE_FORCE_SLIDER_MAX, CHARGE_FORCE_SLIDER_STEP, (value) => {
 						context.config.repelForce = value;
@@ -121,6 +126,7 @@ export function renderActionContainer(context: GraphComponent) {
 			};
 		} else if (action === 'render-external') {
 			actionElement.innerHTML = context.config.renderExternal ? icons.link : icons.unlink;
+			actionElement.ariaLabel = context.config.renderExternal ? 'Hide External Pages' : 'Show External Pages';
 			actionElement.onclick = e => {
 				context.config.renderExternal = !context.config.renderExternal;
 				context.full_refresh();
@@ -142,6 +148,7 @@ export function renderActionContainer(context: GraphComponent) {
 			};
 		} else if (action === 'render-unresolved') {
 			actionElement.innerHTML = context.config.renderUnresolved ? icons.resolved : icons.unresolved;
+			actionElement.ariaLabel = context.config.renderUnresolved ? 'Hide Unresolved Pages' : 'Show Unresolved Pages';
 			actionElement.onclick = e => {
 				context.config.renderUnresolved = !context.config.renderUnresolved;
 				context.full_refresh();

--- a/packages/starlight-site-graph/components/graph/action-element.ts
+++ b/packages/starlight-site-graph/components/graph/action-element.ts
@@ -22,7 +22,7 @@ export function renderActionContainer(context: GraphComponent) {
 
 		if (action === 'fullscreen') {
 			actionElement.innerHTML = context.isFullscreen ? icons.minimize : icons.maximize;
-			actionElement.ariaLabel = context.isFullscreen ? 'Minimize' : 'Maximize';
+			actionElement.title = context.isFullscreen ? 'Minimize' : 'Maximize';
 			actionElement.onclick = e => {
 				context.isFullscreen ? context.disableFullscreen() : context.enableFullscreen();
 				e.stopPropagation();
@@ -35,7 +35,7 @@ export function renderActionContainer(context: GraphComponent) {
 			};
 		} else if (action === 'depth') {
 			actionElement.innerHTML = icons[('graph' + context.config.depth) as keyof typeof icons];
-			actionElement.ariaLabel = `Depth: ${context.config.depth}`;
+			actionElement.title = `Depth: ${context.config.depth}`;
 			actionElement.onclick = e => {
 				context.config.depth = (context.config.depth + 1) % MAX_DEPTH;
 				context.setup();
@@ -67,14 +67,14 @@ export function renderActionContainer(context: GraphComponent) {
 			};
 		} else if (action === 'reset-zoom') {
 			actionElement.innerHTML = icons.focus;
-			actionElement.ariaLabel = 'Reset Zoom';
+			actionElement.title = 'Reset Zoom';
 			actionElement.onclick = e => {
 				context.simulator.resetZoom();
 				e.stopPropagation();
 			};
 		} else if (action === 'render-arrows') {
 			actionElement.innerHTML = context.config.renderArrows ? icons.arrow : icons.line;
-			actionElement.ariaLabel = context.config.renderArrows ? 'Render Arrows' : 'Render Lines';
+			actionElement.title = context.config.renderArrows ? 'Render Arrows' : 'Render Lines';
 			actionElement.onclick = e => {
 				context.config.renderArrows = !context.config.renderArrows;
 				context.simulator.requestRender = true;
@@ -89,7 +89,7 @@ export function renderActionContainer(context: GraphComponent) {
 			};
 		} else if (action === "settings") {
 			actionElement.innerHTML = icons.settings;
-			actionElement.ariaLabel = 'Show Settings';
+			actionElement.title = 'Show Settings';
 			actionElement.onclick = (_) => {
 				const chargeForceSlider = createValueSlider('Repel Force', context.config.repelForce, CHARGE_FORCE_SLIDER_MIN, CHARGE_FORCE_SLIDER_MAX, CHARGE_FORCE_SLIDER_STEP, (value) => {
 						context.config.repelForce = value;
@@ -126,7 +126,7 @@ export function renderActionContainer(context: GraphComponent) {
 			};
 		} else if (action === 'render-external') {
 			actionElement.innerHTML = context.config.renderExternal ? icons.link : icons.unlink;
-			actionElement.ariaLabel = context.config.renderExternal ? 'Hide External Pages' : 'Show External Pages';
+			actionElement.title = context.config.renderExternal ? 'Hide External Pages' : 'Show External Pages';
 			actionElement.onclick = e => {
 				context.config.renderExternal = !context.config.renderExternal;
 				context.full_refresh();
@@ -148,7 +148,7 @@ export function renderActionContainer(context: GraphComponent) {
 			};
 		} else if (action === 'render-unresolved') {
 			actionElement.innerHTML = context.config.renderUnresolved ? icons.resolved : icons.unresolved;
-			actionElement.ariaLabel = context.config.renderUnresolved ? 'Hide Unresolved Pages' : 'Show Unresolved Pages';
+			actionElement.title = context.config.renderUnresolved ? 'Hide Unresolved Pages' : 'Show Unresolved Pages';
 			actionElement.onclick = e => {
 				context.config.renderUnresolved = !context.config.renderUnresolved;
 				context.full_refresh();


### PR DESCRIPTION
Currently the buttons on the site graph may be slightly confusing to new users if they are unfamiliar with the icons. By adding a `title` property on to the html element, it gives a popup tooltip on hover. 

This also makes it so a screen reader or other AT client could read the button and understand what it is doing. Currently since the buttons don't have a `title` or `arialabel` set, a screen reader would just read them as a generic `push button` which is inaccessible. 

I could not find a way to test this with an example so I may need guidance on how to test locally. 

```
host@computer ~/g/s/docs (a11yFixes)> npm i
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
npm error A complete log of this run can be found in: /home/host/.npm/_logs/2025-09-07T18_47_12_197Z-debug-0.log
```