### PR TITLE
refactor(types): tighten up type safety

### DIFF
--- a/packages/starlight-site-graph/components/graph/graph-component.ts
+++ b/packages/starlight-site-graph/components/graph/graph-component.ts
@@ -184,7 +184,10 @@ export class GraphComponent extends HTMLElement {
 				this.simulator.update();
 			}
 			if (requireLabelUpdate) {
-				this.config.labelOpacityScale = diff['labelOpacityScale'].newValue;
+				const labelOpacityScaleDiff = diff['labelOpacityScale'] as { oldValue: unknown; newValue: unknown } | undefined;
+				if (labelOpacityScaleDiff && typeof labelOpacityScaleDiff.newValue === 'number') {
+					this.config.labelOpacityScale = labelOpacityScaleDiff.newValue;
+				}
 				const labelOpacity = this.simulator.getCurrentLabelOpacity();
 				this.animator.startAnimations({
 					labelOpacity,
@@ -194,8 +197,10 @@ export class GraphComponent extends HTMLElement {
 				this.simulator.requestRender = true;
 			}
 			if (requireZoomUpdate) {
-				const scale = diff['scale'].newValue;
-				this.simulator.updateZoom(scale);
+				const scaleDiff = diff['scale'] as { oldValue: unknown; newValue: unknown } | undefined;
+				if (scaleDiff && typeof scaleDiff.newValue === 'number') {
+					this.simulator.updateZoom(scaleDiff.newValue);
+				}
 			}
 			if (requireRendererUpdate) {
 				const newAnimatables = animatables(this.config, this.colors);

--- a/packages/starlight-site-graph/components/graph/graph-component.ts
+++ b/packages/starlight-site-graph/components/graph/graph-component.ts
@@ -184,8 +184,8 @@ export class GraphComponent extends HTMLElement {
 				this.simulator.update();
 			}
 			if (requireLabelUpdate) {
-				const labelOpacityScaleDiff = diff['labelOpacityScale'] as { oldValue: unknown; newValue: unknown } | undefined;
-				if (labelOpacityScaleDiff && typeof labelOpacityScaleDiff.newValue === 'number') {
+				const labelOpacityScaleDiff = diff['labelOpacityScale'];
+				if (labelOpacityScaleDiff) {
 					this.config.labelOpacityScale = labelOpacityScaleDiff.newValue;
 				}
 				const labelOpacity = this.simulator.getCurrentLabelOpacity();
@@ -197,13 +197,13 @@ export class GraphComponent extends HTMLElement {
 				this.simulator.requestRender = true;
 			}
 			if (requireZoomUpdate) {
-				const scaleDiff = diff['scale'] as { oldValue: unknown; newValue: unknown } | undefined;
-				if (scaleDiff && typeof scaleDiff.newValue === 'number') {
+				const scaleDiff = diff['scale'];
+				if (scaleDiff) {
 					this.simulator.updateZoom(scaleDiff.newValue);
 				}
 			}
 			if (requireRendererUpdate) {
-				const newAnimatables = animatables(this.config, this.colors);
+				const newAnimatables = animatables(this.config, this.colors, []);
 				// TODO: This could be made more efficient by only updating the changed properties
 				for (const [key, value] of Object.entries(newAnimatables)) {
 					this.animator.setProperties(key, (value as any).properties);

--- a/packages/starlight-site-graph/components/graph/graph-component.ts
+++ b/packages/starlight-site-graph/components/graph/graph-component.ts
@@ -17,7 +17,7 @@ import {
 	MAX_DEPTH
 } from './constants';
 import { setSlashes } from '../../sitemap/util';
-import { onClickOutside, deepDiff, deepMerge } from '../util';
+import { onClickOutside, deepDiff, mergeDefaults } from '../util';
 import { GraphSimulator } from './simulator';
 
 export class GraphComponent extends HTMLElement {
@@ -232,7 +232,7 @@ export class GraphComponent extends HTMLElement {
 	}
 
 	setConfigListener(config?: string) {
-		const mergedConfig = deepMerge(globalGraphConfig, JSON.parse(config || '{}'));
+		const mergedConfig = mergeDefaults(globalGraphConfig, JSON.parse(config || '{}'));
 		const validatedConfig = this.validateConfig(mergedConfig);
 		this.config = new Proxy(validatedConfig, {
 			set: (target, prop, value) => {

--- a/packages/starlight-site-graph/components/graph/graph-component.ts
+++ b/packages/starlight-site-graph/components/graph/graph-component.ts
@@ -1,4 +1,4 @@
-import { type GraphConfig, type RemoveOptional, type Sitemap, globalGraphConfig } from '../../config';
+import { type GraphConfig, type Sitemap, globalGraphConfig } from '../../config';
 
 import { Animator } from '../animator';
 import { animatables } from './animatables';
@@ -34,7 +34,7 @@ export class GraphComponent extends HTMLElement {
 	renderer!: GraphRenderer;
 	simulator!: GraphSimulator;
 
-	config!: RemoveOptional<GraphConfig>;
+	config!: GraphConfig;
 	sitemap!: Sitemap;
 
 	defaultColorTransitions!: Record<string, string>;

--- a/packages/starlight-site-graph/components/graph/simulator.ts
+++ b/packages/starlight-site-graph/components/graph/simulator.ts
@@ -86,7 +86,7 @@ export class GraphSimulator {
 	}
 
 	update() {
-		const linkForce = d3.forceLink(this.links).id((d: any) => d.id);
+		const linkForce = d3.forceLink<NodeData, LinkData>(this.links).id((d) => d.id);
 		if (this.context.config.linkDistance) {
 			linkForce.distance(this.context.config.linkDistance);
 		}
@@ -95,13 +95,13 @@ export class GraphSimulator {
 			.stop()
 			.force('link', linkForce)
 			.force('charge', d3.forceManyBody().distanceMax(500).strength(-this.context.config.repelForce))
-			.force('forceX', d3.forceX().strength(this.context.config.centerForce))
-			.force('forceY', d3.forceY().strength(this.context.config.centerForce))
+			.force('forceX', d3.forceX<NodeData>().strength(this.context.config.centerForce))
+			.force('forceY', d3.forceY<NodeData>().strength(this.context.config.centerForce))
 			.force(
 				'collision',
 				d3
-					.forceCollide()
-					.radius(node => (node as NodeData).colliderSize! + this.context.config.colliderPadding),
+					.forceCollide<NodeData>()
+					.radius(node => node.colliderSize! + this.context.config.colliderPadding),
 			)
 			.alphaDecay(this.context.config.alphaDecay)
 			.alpha(1)

--- a/packages/starlight-site-graph/components/graph/simulator.ts
+++ b/packages/starlight-site-graph/components/graph/simulator.ts
@@ -94,7 +94,7 @@ export class GraphSimulator {
 		this.simulation
 			.stop()
 			.force('link', linkForce)
-			.force('charge', d3.forceManyBody().distanceMax(500).strength(-this.context.config.repelForce))
+			.force('charge', d3.forceManyBody<NodeData>().distanceMax(500).strength(-this.context.config.repelForce))
 			.force('forceX', d3.forceX<NodeData>().strength(this.context.config.centerForce))
 			.force('forceY', d3.forceY<NodeData>().strength(this.context.config.centerForce))
 			.force(

--- a/packages/starlight-site-graph/components/util.ts
+++ b/packages/starlight-site-graph/components/util.ts
@@ -112,11 +112,14 @@ export function hasTouch() {
 	return 'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints! > 0;
 }
 
-export function deepDiff(obj1: any, obj2: any): any {
-	const changes: any = {};
+type DiffValue = { oldValue: unknown; newValue: unknown };
+type DiffResult = Record<string, DiffValue | DiffResult>;
 
-	function compareValues(key: string, value1: any, value2: any) {
-		if (typeof value1 === 'object' && typeof value2 === 'object') {
+export function deepDiff(obj1: unknown, obj2: unknown): DiffResult {
+	const changes: DiffResult = {};
+
+	function compareValues(key: string, value1: unknown, value2: unknown) {
+		if (isObject(value1) && isObject(value2)) {
 			const nestedDiff = deepDiff(value1, value2);
 			if (Object.keys(nestedDiff).length > 0) {
 				changes[key] = nestedDiff;
@@ -124,6 +127,10 @@ export function deepDiff(obj1: any, obj2: any): any {
 		} else if (value1 !== value2) {
 			changes[key] = { oldValue: value1, newValue: value2 };
 		}
+	}
+
+	if (!isObject(obj1) || !isObject(obj2)) {
+		return changes;
 	}
 
 	const allKeys = new Set([...Object.keys(obj1), ...Object.keys(obj2)]);
@@ -145,14 +152,14 @@ export function deepDiff(obj1: any, obj2: any): any {
 	return changes;
 }
 
-function isObject(item: any): boolean {
-	return (item && typeof item === 'object' && !Array.isArray(item));
+function isObject(item: unknown): item is Record<string, unknown> {
+	return (item !== null && typeof item === 'object' && !Array.isArray(item));
 }
 
 /**
  * NOTE: Adapted from https://stackoverflow.com/a/37164538/23278914
  */
-export function deepMerge(target: any, source: any): any {
+export function deepMerge(target: unknown, source: unknown): any {
 	let output = Object.assign({}, target);
 	if (isObject(target) && isObject(source)) {
 		for (const [key, value] of Object.entries(source)) {

--- a/packages/starlight-site-graph/components/util.ts
+++ b/packages/starlight-site-graph/components/util.ts
@@ -112,70 +112,59 @@ export function hasTouch() {
 	return 'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints! > 0;
 }
 
-type DiffValue = { oldValue: unknown; newValue: unknown };
-type DiffResult = Record<string, DiffValue | DiffResult>;
-
-export function deepDiff(obj1: unknown, obj2: unknown): DiffResult {
-	const changes: DiffResult = {};
-
-	function compareValues(key: string, value1: unknown, value2: unknown) {
-		if (isObject(value1) && isObject(value2)) {
-			const nestedDiff = deepDiff(value1, value2);
-			if (Object.keys(nestedDiff).length > 0) {
-				changes[key] = nestedDiff;
-			}
-		} else if (value1 !== value2) {
-			changes[key] = { oldValue: value1, newValue: value2 };
-		}
-	}
-
-	if (!isObject(obj1) || !isObject(obj2)) {
-		return changes;
-	}
-
-	const allKeys = new Set([...Object.keys(obj1), ...Object.keys(obj2)]);
-
-	for (const key of allKeys) {
-		const value1 = obj1[key];
-		const value2 = obj2[key];
-
-		// Check if key exists in both objects
-		if (key in obj1 && !(key in obj2)) {
-			changes[key] = { oldValue: value1, newValue: undefined };
-		} else if (!(key in obj1) && key in obj2) {
-			changes[key] = { oldValue: undefined, newValue: value2 };
-		} else {
-			compareValues(key, value1, value2);
-		}
-	}
-
-	return changes;
-}
-
 function isObject(item: unknown): item is Record<string, unknown> {
 	return (item !== null && typeof item === 'object' && !Array.isArray(item));
 }
 
-/**
- * NOTE: Adapted from https://stackoverflow.com/a/37164538/23278914
- */
-export function deepMerge(target: unknown, source: unknown): any {
-	let output = Object.assign({}, target);
-	if (isObject(target) && isObject(source)) {
-		for (const [key, value] of Object.entries(source)) {
-			if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
-				continue;
-			}
+type DiffValue<V> = { oldValue: V; newValue: V };
+type DeepDiffResult<T> = {
+	[K in keyof T]?: T[K] extends Record<string, unknown>
+		? DeepDiffResult<T[K]> | DiffValue<T[K]>
+		: DiffValue<T[K]>;
+};
 
-			if (isObject(value)) {
-				if (!(key in target))
-					Object.assign(output, { [key]: value });
-				else
-					output[key] = deepMerge(target[key], value);
-			} else {
-				Object.assign(output, { [key]: value });
+export function deepDiff<T extends Record<string, unknown>>(obj1: T, obj2: T): DeepDiffResult<T> {
+	const changes: Partial<Record<keyof T, unknown>> = {};
+	const allKeys = Object.keys({ ...obj1, ...obj2 }) as (keyof T)[];
+
+	for (const key of allKeys) {
+		const val1 = obj1[key];
+		const val2 = obj2[key];
+
+		if (isObject(val1) && isObject(val2)) {
+			const nested = deepDiff(val1 as Record<string, unknown>, val2 as Record<string, unknown>);
+			if (Object.keys(nested).length > 0) {
+				changes[key] = nested;
 			}
+		} else if (val1 !== val2) {
+			changes[key] = { oldValue: val1, newValue: val2 };
 		}
 	}
-	return output;
+	return changes as DeepDiffResult<T>;
+}
+
+type DeepPartial<T> = {
+	[P in keyof T]?: T[P] extends Record<string, unknown>
+		? DeepPartial<T[P]> | undefined
+		: T[P] | undefined;
+};
+
+export function mergeDefaults<T extends Record<string, unknown>>(base: T, patch: DeepPartial<T>): T {
+	const result: Record<string, unknown> = { ...base };
+	for (const key of Object.keys(base)) {
+		if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+			continue;
+		}
+
+		const baseValue = result[key];
+		const patchValue = patch[key];
+
+		if (isObject(patchValue) && isObject(baseValue)) {
+			result[key] = mergeDefaults(baseValue, patchValue);
+		} else if (patchValue !== undefined) {
+			result[key] = patchValue;
+		}
+	}
+
+	return result as T;
 }

--- a/packages/starlight-site-graph/config/backlinks.ts
+++ b/packages/starlight-site-graph/config/backlinks.ts
@@ -1,8 +1,12 @@
 import { z } from 'astro/zod';
 
-export const globalBacklinksConfig = {
+const DEFAULT_BACKLINKS_CONFIG = {
 	visibilityRules: ['**/*'],
-}
+};
+
+export const globalBacklinksConfig = {
+	...DEFAULT_BACKLINKS_CONFIG,
+} satisfies BacklinksConfig;
 
 export const globalBacklinksConfigSchema = z.object({
 	/**
@@ -20,7 +24,7 @@ export const globalBacklinksConfigSchema = z.object({
 	 * ["!secret/**", "**\/*"]
 	 * @see https://github.com/mrmlnc/fast-glob#basic-syntax
 	 */
-	visibilityRules: z.array(z.string()).default(globalBacklinksConfig.visibilityRules),
-}).partial();
+	visibilityRules: z.array(z.string()).default([...DEFAULT_BACKLINKS_CONFIG.visibilityRules]),
+});
 
 export type BacklinksConfig = z.infer<typeof globalBacklinksConfigSchema>;

--- a/packages/starlight-site-graph/config/base.ts
+++ b/packages/starlight-site-graph/config/base.ts
@@ -4,17 +4,23 @@ import { globalGraphConfigSchema, globalGraphConfig } from './graph';
 import { globalSitemapConfigSchema, globalSitemapConfig } from './sitemap';
 import { globalBacklinksConfigSchema, globalBacklinksConfig } from './backlinks';
 
+const KWD_TRACK_VISITED_PAGES = ['disable', 'session', 'local'] as const;
 
-export const starlightSiteGraphConfig = {
+const DEFAULT_GLOBAL_STARLIGHT_CONFIG = {
 	debug: false,
 	overridePageSidebar: true,
-	trackVisitedPages: 'session' as 'disable' | 'session' | 'local',
+	trackVisitedPages: 'session' as typeof KWD_TRACK_VISITED_PAGES[number],
 	graph: true,
 	graphConfig: globalGraphConfig,
 	sitemapConfig: globalSitemapConfig,
 	backlinks: true,
 	backlinksConfig: globalBacklinksConfig,
-}
+};
+
+export const starlightSiteGraphConfig = {
+	starlight: false,
+	...DEFAULT_GLOBAL_STARLIGHT_CONFIG,
+};
 
 export const starlightSiteGraphConfigSchema = z
 	.object({
@@ -29,12 +35,12 @@ export const starlightSiteGraphConfigSchema = z
 		 *
 		 * @default false
 		 */
-		debug: z.boolean().default(starlightSiteGraphConfig.debug),
+		debug: z.boolean().default(DEFAULT_GLOBAL_STARLIGHT_CONFIG.debug),
 
 		/**
 		 * Override the sidebar component for the graph, disabling this will completely remove both the graph and backlinks from the sidebar.
 		 */
-		overridePageSidebar: z.boolean().default(starlightSiteGraphConfig.overridePageSidebar),
+		overridePageSidebar: z.boolean().default(DEFAULT_GLOBAL_STARLIGHT_CONFIG.overridePageSidebar),
 
 		/**
 		 * Whether to track pages of the website that were visited by the user.
@@ -47,8 +53,8 @@ export const starlightSiteGraphConfigSchema = z
 		 * @default "session"
 		 */
 		trackVisitedPages: z
-			.union([z.literal('disable'), z.literal('session'), z.literal('local')])
-			.default(starlightSiteGraphConfig.trackVisitedPages as 'disable' | 'session' | 'local'),
+			.enum(KWD_TRACK_VISITED_PAGES)
+			.default(DEFAULT_GLOBAL_STARLIGHT_CONFIG.trackVisitedPages),
 
 		/**
 		 * Whether to add a graph component to the sidebar, acts as a global toggle for the graph.
@@ -56,7 +62,7 @@ export const starlightSiteGraphConfigSchema = z
 		 * @remarks If false, it is equivalent to setting `graphConfig.visibilityRules` an empty array
 		 * @default true
 		 */
-		graph: z.boolean().default(starlightSiteGraphConfig.graph),
+		graph: z.boolean().default(DEFAULT_GLOBAL_STARLIGHT_CONFIG.graph),
 
 		/**
 		 * Configuration for the PageSidebar graph component.
@@ -129,7 +135,7 @@ export const starlightSiteGraphConfigSchema = z
 		 *     alphaDecay: 0.0228
 		 * }```
 		 */
-		graphConfig: globalGraphConfigSchema.default(starlightSiteGraphConfig.graphConfig),
+		graphConfig: globalGraphConfigSchema.partial().default({ ...DEFAULT_GLOBAL_STARLIGHT_CONFIG.graphConfig }),
 
 		/**
 		 * Configuration for the sitemap generation.
@@ -141,7 +147,7 @@ export const starlightSiteGraphConfigSchema = z
 		 *    linkInclusionRules: ["**\/*"],
 		 * }```
 		 */
-		sitemapConfig: globalSitemapConfigSchema.default(starlightSiteGraphConfig.sitemapConfig),
+		sitemapConfig: globalSitemapConfigSchema.partial().default({ ...DEFAULT_GLOBAL_STARLIGHT_CONFIG.sitemapConfig }),
 
 		/**
 		 * Whether to add a backlinks panel to the sidebar, acts as a global toggle for the backlinks.
@@ -149,7 +155,7 @@ export const starlightSiteGraphConfigSchema = z
 		 * @remarks If false, it is equivalent to setting `backlinksConfig.visibilityRules` an empty array
 		 * @default true
 		 */
-		backlinks: z.boolean().default(starlightSiteGraphConfig.backlinks),
+		backlinks: z.boolean().default(DEFAULT_GLOBAL_STARLIGHT_CONFIG.backlinks),
 
 		/**
 		 * Configuration for the PageSidebar backlinks component.
@@ -158,7 +164,7 @@ export const starlightSiteGraphConfigSchema = z
 		 *   visibilityRules: ["**\/*"],
 		 * }```
 		 */
-		backlinksConfig: globalBacklinksConfigSchema.default(starlightSiteGraphConfig.backlinksConfig),
+		backlinksConfig: globalBacklinksConfigSchema.partial().default({ ...DEFAULT_GLOBAL_STARLIGHT_CONFIG.backlinksConfig }),
 	})
 	.partial()
 	.default({});

--- a/packages/starlight-site-graph/config/graph.ts
+++ b/packages/starlight-site-graph/config/graph.ts
@@ -5,27 +5,29 @@ import {
 	nodeUnresolvedStyle, nodeVisitedStyle, tagDefaultStyle
 } from './node';
 
-const easingTypes = z.union([
-	z.literal('in_quad'),
-	z.literal('out_quad'),
-	z.literal('in_out_quad'),
-	z.literal('linear'),
-]);
+const KWD_GRAPH_ACTIONS = ['fullscreen', 'depth', 'reset-zoom', 'render-arrows', 'render-external', 'render-unresolved', 'settings'] as const;
+const KWD_TAG_RENDER_MODES = ['none', 'node', 'same', 'both'] as const;
+const KWD_CLICK_MODES = ['auto', 'disable', 'click', 'dblclick'] as const;
+const KWD_DEPTH_DIRECTIONS = ['both', 'incoming', 'outgoing'] as const;
+const KWD_FOLLOW_LINK_MODES = ['same', 'new-tab', 'graph'] as const;
+const KWD_EASING_TYPES = ['in_quad', 'out_quad', 'in_out_quad', 'linear'] as const;
 
-const graphConfig = {
-	actions: ['fullscreen', 'depth', 'reset-zoom', 'render-arrows', 'settings'] as ('fullscreen' | 'depth' | 'reset-zoom' | 'render-arrows' | 'settings')[],
+const easingTypes = z.enum(KWD_EASING_TYPES);
+
+const DEFAULT_GRAPH_CONFIG = {
+	actions: ['fullscreen', 'depth', 'reset-zoom', 'render-arrows', 'settings'] as (typeof KWD_GRAPH_ACTIONS[number])[],
 	tagStyles: {},
-	tagRenderMode: 'none' as ('none' | 'node' | 'same' | 'both'),
-	nodeInclusionRules: ['**/*'] as const,
+	tagRenderMode: 'none' as typeof KWD_TAG_RENDER_MODES[number],
+	nodeInclusionRules: ['**/*'],
 	prefetchPages: true,
 	enableDrag: true,
 	enableZoom: true,
 	enablePan: true,
 	enableHover: true,
-	enableClick: 'auto' as ('auto' | 'disable' | 'click' | 'dblclick'),
+	enableClick: 'auto' as typeof KWD_CLICK_MODES[number],
 	depth: 1,
-	depthDirection: 'both' as ('both' | 'incoming' | 'outgoing'),
-	followLink: 'same' as ('same' | 'new-tab' | 'graph'),
+	depthDirection: 'both' as typeof KWD_DEPTH_DIRECTIONS[number],
+	followLink: 'same' as typeof KWD_FOLLOW_LINK_MODES[number],
 	scale: 1.1,
 	minZoom: 0.05,
 	maxZoom: 4,
@@ -45,9 +47,9 @@ const graphConfig = {
 	labelOffset: 10,
 	labelHoverOffset: 14,
 	zoomDuration: 75,
-	zoomEase: 'out_quad' as 'in_quad' | 'out_quad' | 'in_out_quad' | 'linear',
+	zoomEase: 'out_quad' as typeof KWD_EASING_TYPES[number],
 	hoverDuration: 200,
-	hoverEase: 'out_quad' as 'in_quad' | 'out_quad' | 'in_out_quad' | 'linear',
+	hoverEase: 'out_quad' as typeof KWD_EASING_TYPES[number],
 	nodeDefaultStyle: nodeDefaultStyle,
 	nodeVisitedStyle: nodeVisitedStyle,
 	nodeCurrentStyle: nodeCurrentStyle,
@@ -64,10 +66,15 @@ const graphConfig = {
 	linkDistance: 0,
 	alphaDecay: 0.0228,
 };
-export const globalGraphConfig = {
-	...graphConfig,
+
+const DEFAULT_GLOBAL_GRAPH_CONFIG = {
+	...DEFAULT_GRAPH_CONFIG,
 	visibilityRules: ['**/*'],
-}
+};
+
+export const globalGraphConfig = {
+	...DEFAULT_GLOBAL_GRAPH_CONFIG
+} satisfies GraphConfig;
 
 export const graphConfigSchema = z.object({
 	/**
@@ -84,18 +91,8 @@ export const graphConfigSchema = z.object({
 	 * @default ["fullscreen", "depth", "reset-zoom", "render-arrows", "settings"]
 	 */
 	actions: z
-		.array(
-			z.union([
-				z.literal('fullscreen'),
-				z.literal('depth'),
-				z.literal('reset-zoom'),
-				z.literal('render-arrows'),
-				z.literal('render-external'),
-				z.literal('render-unresolved'),
-				z.literal('settings')
-			]),
-		)
-		.default(graphConfig.actions),
+		.array(z.enum(KWD_GRAPH_ACTIONS))
+		.default(DEFAULT_GRAPH_CONFIG.actions),
 
 	/**
 	 * Define shape, color and size, and stroke of specified tags
@@ -109,7 +106,7 @@ export const graphConfigSchema = z.object({
 			z.string().transform(val => (!val.startsWith('#') ? '#' + val : val)),
 			nodeStyleSchema.partial(),
 		)
-		.default(graphConfig.tagStyles),
+		.default(DEFAULT_GRAPH_CONFIG.tagStyles),
 	/**
 	 * How tags should be rendered in the graph
 	 * - `none`: Tags are not rendered at all
@@ -122,39 +119,39 @@ export const graphConfigSchema = z.object({
 	 * @default "none"
 	 */
 	tagRenderMode: z
-		.union([z.literal('none'), z.literal('node'), z.literal('same'), z.literal('both')])
-		.default(graphConfig.tagRenderMode),
+		.enum(KWD_TAG_RENDER_MODES)
+		.default(DEFAULT_GRAPH_CONFIG.tagRenderMode),
 
 	/**
 	 * Whether to prefetch pages on hover in the graph component.
 	 *
 	 * @default true
 	 */
-	prefetchPages: z.boolean().default(globalGraphConfig.prefetchPages),
+	prefetchPages: z.boolean().default(DEFAULT_GRAPH_CONFIG.prefetchPages),
 
 	/**
 	 * Whether to enable user dragging of nodes in the graph
 	 *
 	 * @default true
 	 */
-	enableDrag: z.boolean().default(graphConfig.enableDrag),
+	enableDrag: z.boolean().default(DEFAULT_GRAPH_CONFIG.enableDrag),
 	/**
 	 * Whether to enable user zooming of the graph
 	 *
 	 * @default true
 	 */
-	enableZoom: z.boolean().default(graphConfig.enableZoom),
+	enableZoom: z.boolean().default(DEFAULT_GRAPH_CONFIG.enableZoom),
 	/**
 	 * Whether to enable user panning of the graph (i.e. moving left/right/up/down)
 	 */
-	enablePan: z.boolean().default(graphConfig.enablePan),
+	enablePan: z.boolean().default(DEFAULT_GRAPH_CONFIG.enablePan),
 	/**
 	 * Whether to enable hover interactions on the graph
 	 * This includes highlighting nodes and links on hover, and showing labels
 	 *
 	 * @default true
 	 */
-	enableHover: z.boolean().default(graphConfig.enableHover),
+	enableHover: z.boolean().default(DEFAULT_GRAPH_CONFIG.enableHover),
 	/**
 	 * The mode of interaction to trigger the page navigation
 	 *
@@ -166,8 +163,8 @@ export const graphConfigSchema = z.object({
 	 * @default "auto"
 	 */
 	enableClick: z
-		.union([z.literal('auto'), z.literal('disable'), z.literal('click'), z.literal('dblclick')])
-		.default(graphConfig.enableClick),
+		.enum(KWD_CLICK_MODES)
+		.default(DEFAULT_GRAPH_CONFIG.enableClick),
 
 
 	/**
@@ -183,7 +180,7 @@ export const graphConfigSchema = z.object({
 	 * @example Include all files except those in the "secret" folder:
 	 * ["!secret/**", "**\/*"]
 	 */
-	nodeInclusionRules: z.array(z.string()).default(graphConfig.nodeInclusionRules),
+	nodeInclusionRules: z.array(z.string()).default([...DEFAULT_GRAPH_CONFIG.nodeInclusionRules]),
 
 	/**
 	 * The depth of the graph, determines how many levels of links are shown. \
@@ -197,7 +194,7 @@ export const graphConfigSchema = z.object({
 	 * @remarks For performance reasons, the depth is capped at `6`.
 	 * @default 1
 	 */
-	depth: z.number().default(graphConfig.depth),
+	depth: z.number().default(DEFAULT_GRAPH_CONFIG.depth),
 	/**
 	 * In which direction the depth of the graph should be expanded
 	 * - `both`: Expand in both incoming and outgoing directions
@@ -207,8 +204,8 @@ export const graphConfigSchema = z.object({
 	 * @default "both"
 	 */
 	depthDirection: z
-		.union([z.literal('both'), z.literal('incoming'), z.literal('outgoing')])
-		.default(graphConfig.depthDirection),
+		.enum(KWD_DEPTH_DIRECTIONS)
+		.default(DEFAULT_GRAPH_CONFIG.depthDirection),
 
 	/**
 	 * Determine what should happen when a link is followed
@@ -220,8 +217,8 @@ export const graphConfigSchema = z.object({
 	 * @default "tab"
 	 */
 	followLink: z
-		.union([z.literal('same'), z.literal('new-tab'), z.literal('graph')])
-		.default(graphConfig.followLink),
+		.enum(KWD_FOLLOW_LINK_MODES)
+		.default(DEFAULT_GRAPH_CONFIG.followLink),
 
 
 	/**
@@ -229,65 +226,65 @@ export const graphConfigSchema = z.object({
 	 *
 	 * @default 1.1
 	 */
-	scale: z.number().gt(0, "Graph scale may not be zero or negative").default(graphConfig.scale),
+	scale: z.number().gt(0, "Graph scale may not be zero or negative").default(DEFAULT_GRAPH_CONFIG.scale),
 	/**
 	 * The minimum zoom level of the graph
 	 *
 	 * @default 0.05
 	 */
-	minZoom: z.number().gt(0, "Graph zoom may not be zero or negative").default(graphConfig.minZoom),
+	minZoom: z.number().gt(0, "Graph zoom may not be zero or negative").default(DEFAULT_GRAPH_CONFIG.minZoom),
 	/**
 	 * The maximum zoom level of the graph
 	 *
 	 * @default 4
 	 */
-	maxZoom: z.number().gt(0, "Graph zoom may not be zero or negative").default(graphConfig.maxZoom),
+	maxZoom: z.number().gt(0, "Graph zoom may not be zero or negative").default(DEFAULT_GRAPH_CONFIG.maxZoom),
 
 	/**
 	 * Whether to render page title labels on the nodes
 	 *
 	 * @default true
 	 */
-	renderLabels: z.boolean().default(graphConfig.renderLabels),
+	renderLabels: z.boolean().default(DEFAULT_GRAPH_CONFIG.renderLabels),
 	/**
 	 * Whether to render arrows on the links
 	 *
 	 * @default true
 	 */
-	renderArrows: z.boolean().default(graphConfig.renderArrows),
+	renderArrows: z.boolean().default(DEFAULT_GRAPH_CONFIG.renderArrows),
 	/**
 	 * Whether to render unresolved pages in the graph
 	 *
 	 * @default false
 	 */
-	renderUnresolved: z.boolean().default(graphConfig.renderUnresolved),
+	renderUnresolved: z.boolean().default(DEFAULT_GRAPH_CONFIG.renderUnresolved),
 	/**
 	 * Whether to render external pages in the graph
 	 *
 	 * @remarks External nodes only exist in the sitemap if `includeExternalLinks` of `sitemapConfig` is set to `true`.
 	 * @default true
 	 */
-	renderExternal: z.boolean().default(graphConfig.renderExternal),
+	renderExternal: z.boolean().default(DEFAULT_GRAPH_CONFIG.renderExternal),
 
 	/**
 	 * Whether to scale the links based on the zoom level
 	 *
 	 * @default true
 	 */
-	scaleLinks: z.boolean().default(graphConfig.scaleLinks),
+	scaleLinks: z.boolean().default(DEFAULT_GRAPH_CONFIG.scaleLinks),
 	/**
 	 * Whether to scale the arrows based on the zoom level
 	 *
 	 * @default false
 	 */
-	scaleArrows: z.boolean().default(graphConfig.scaleArrows),
+	scaleArrows: z.boolean().default(DEFAULT_GRAPH_CONFIG.scaleArrows),
 	/**
 	 * Minimum zoom level at which the arrows are rendered \
 	 * When 0, arrows will always be rendered
 	 *
 	 * @default 0.8
 	 */
-	minZoomArrows: z.number().min(0, "Minimum zoom for arrow rendering may not be negative").default(graphConfig.minZoomArrows),
+	minZoomArrows: z.number().min(0, "Minimum zoom for arrow rendering may not be negative").default(DEFAULT_GRAPH_CONFIG.minZoomArrows),
 
 	/**
 	 * The scale factor for the opacity of the labels, based on the zoom level
@@ -295,49 +292,49 @@ export const graphConfigSchema = z.object({
 	 *
 	 * @default 1.3
 	 */
-	labelOpacityScale: z.number().min(0, "Opacity scale for labels may not be negative").default(graphConfig.labelOpacityScale),
+	labelOpacityScale: z.number().min(0, "Opacity scale for labels may not be negative").default(DEFAULT_GRAPH_CONFIG.labelOpacityScale),
 	/**
 	 * The opacity of unhovered labels (when hovering over a node)
 	 *
 	 * @default 0
 	 */
-	labelMutedOpacity: z.number().min(0, "Opacity scale for muted labels may not be negative").default(graphConfig.labelMutedOpacity),
+	labelMutedOpacity: z.number().min(0, "Opacity scale for muted labels may not be negative").default(DEFAULT_GRAPH_CONFIG.labelMutedOpacity),
 	/**
 	 * The opacity of the label when hovering over a node
 	 *
 	 * @default 1
 	 */
-	labelHoverOpacity: z.number().min(0, "Opacity scale for hovered labels may not be negative").default(graphConfig.labelHoverOpacity),
+	labelHoverOpacity: z.number().min(0, "Opacity scale for hovered labels may not be negative").default(DEFAULT_GRAPH_CONFIG.labelHoverOpacity),
 	/**
 	 * The opacity of the label when adjacent to the hovered node. \
 	 * If explicitly set to undefined, the `labelMutedOpacity` will be used.
 	 */
-	labelAdjacentOpacity: z.number().min(0, "Opacity scale for hovered labels may not be negative").optional().default(graphConfig.labelAdjacentOpacity),
+	labelAdjacentOpacity: z.number().min(0, "Opacity scale for hovered labels may not be negative").optional().default(DEFAULT_GRAPH_CONFIG.labelAdjacentOpacity),
 	/**
 	 * The font size of the labels
 	 *
 	 * @remarks Labels should be disabled using the `renderLabels` option
 	 * @default 12
 	 */
-	labelFontSize: z.number().min(0, "Label font size may not be negative").default(graphConfig.labelFontSize),
+	labelFontSize: z.number().min(0, "Label font size may not be negative").default(DEFAULT_GRAPH_CONFIG.labelFontSize),
 	/**
 	 * The scale of the label when hovering over a node
 	 *
 	 * @default 1
 	 */
-	labelHoverScale: z.number().min(0, "Label hover scale may not be negative").default(graphConfig.labelHoverScale),
+	labelHoverScale: z.number().min(0, "Label hover scale may not be negative").default(DEFAULT_GRAPH_CONFIG.labelHoverScale),
 	/**
 	 * The offset of the labels from the nodes
 	 *
 	 * @default 10
 	 */
-	labelOffset: z.number().min(0, "Label offset may not be negative").default(graphConfig.labelOffset),
+	labelOffset: z.number().min(0, "Label offset may not be negative").default(DEFAULT_GRAPH_CONFIG.labelOffset),
 	/**
 	 * The offset of the label from the node when hovering over said node
 	 *
 	 * @default 14
 	 */
-	labelHoverOffset: z.number().min(0, "Label hover offset may not be negative").default(graphConfig.labelHoverOffset),
+	labelHoverOffset: z.number().min(0, "Label hover offset may not be negative").default(DEFAULT_GRAPH_CONFIG.labelHoverOffset),
 
 	/**
 	 * The duration of the zoom animation in milliseconds \
@@ -345,28 +342,28 @@ export const graphConfigSchema = z.object({
 	 *
 	 * @default 75
 	 */
-	zoomDuration: z.number().min(0, "Zoom duration may not be negative").default(graphConfig.zoomDuration),
+	zoomDuration: z.number().min(0, "Zoom duration may not be negative").default(DEFAULT_GRAPH_CONFIG.zoomDuration),
 	/**
 	 * The easing function for the zoom animation
 	 * This controls the acceleration of zooming and panning
 	 *
 	 * @default "out_quad"
 	 */
-	zoomEase: easingTypes.default(graphConfig.zoomEase),
+	zoomEase: easingTypes.default(DEFAULT_GRAPH_CONFIG.zoomEase),
 	/**
 	 * The duration of the hover animation in milliseconds
 	 * This controls the speed of the node/link/label highlighting transitions
 	 *
 	 * @default 200
 	 */
-	hoverDuration: z.number().min(0, "Hover duration may not be negative").default(graphConfig.hoverDuration),
+	hoverDuration: z.number().min(0, "Hover duration may not be negative").default(DEFAULT_GRAPH_CONFIG.hoverDuration),
 	/**
 	 * The easing function for the hover animation
 	 * This controls the acceleration of the node/link/label highlighting transitions
 	 *
 	 * @default "out_quad"
 	 */
-	hoverEase: easingTypes.default(graphConfig.hoverEase),
+	hoverEase: easingTypes.default(DEFAULT_GRAPH_CONFIG.hoverEase),
 
 	/**
 	 * The default style of a node in the graph. \
@@ -436,26 +433,26 @@ export const graphConfigSchema = z.object({
 	 *
 	 * @default 1
 	 */
-	linkWidth: z.number().min(0, "Link width may not be negative").default(1),
+	linkWidth: z.number().min(0, "Link width may not be negative").default(DEFAULT_GRAPH_CONFIG.linkWidth),
 	/**
 	 * The width of the hovered links in the graph
 	 *
 	 * @default 1
 	 */
-	linkHoverWidth: z.number().min(0, "Hover link width may not be negative").default(1),
+	linkHoverWidth: z.number().min(0, "Hover link width may not be negative").default(DEFAULT_GRAPH_CONFIG.linkHoverWidth),
 
 	/**
 	 * The size of the arrows on the links
 	 *
 	 * @default 5
 	 */
-	arrowSize: z.number().min(0, "Arrow size may not be negative").default(5),
+	arrowSize: z.number().min(0, "Arrow size may not be negative").default(DEFAULT_GRAPH_CONFIG.arrowSize),
 	/**
 	 * The angle of the arrowhead of the links, a smaller angle will make the arrowhead pointier
 	 *
 	 * @default Math.PI / 6
 	 */
-	arrowAngle: z.number().min(0, "Arrow angle may not be negative").default(Math.PI / 6),
+	arrowAngle: z.number().min(0, "Arrow angle may not be negative").default(DEFAULT_GRAPH_CONFIG.arrowAngle),
 
 	/**
 	 * The strength of the force that pulls nodes towards the center of the graph. \
@@ -463,28 +460,28 @@ export const graphConfigSchema = z.object({
 	 *
 	 * @default 0.05
 	 */
-	centerForce: z.number().min(0, "Center force may not be negative").default(0.05),
+	centerForce: z.number().min(0, "Center force may not be negative").default(DEFAULT_GRAPH_CONFIG.centerForce),
 	/**
 	 * The collision force between nodes in the graph. \
 	 * A higher value will make nodes repel each other more strongly, creating an even, grid-like layout
 	 *
 	 * @default 20
 	 */
-	colliderPadding: z.number().min(0, "Collider padding may not be negative").default(20),
+	colliderPadding: z.number().min(0, "Collider padding may not be negative").default(DEFAULT_GRAPH_CONFIG.colliderPadding),
 	/**
 	 * The attraction/repulsion force between nodes in the graph. \
 	 * A higher value will increase the distance between nodes
 	 *
 	 * @default 200
 	 */
-	repelForce: z.number().min(0, "Repel force may not be negative").default(200),
+	repelForce: z.number().min(0, "Repel force may not be negative").default(DEFAULT_GRAPH_CONFIG.repelForce),
 	/**
 	 * The distance between linked nodes in the graph. \
 	 * If set to 0, link distance are determined by the force simulation
 	 *
 	 * @default 0
 	 */
-	linkDistance: z.number().min(0, "Link distance may not be negative").default(0),
+	linkDistance: z.number().min(0, "Link distance may not be negative").default(DEFAULT_GRAPH_CONFIG.linkDistance),
 	/**
 	 * The speed at which the graph stabilizes after a simulation update. \
 	 * A higher value will make the graph stabilize faster, but may result in a less accurate layout. \
@@ -492,8 +489,8 @@ export const graphConfigSchema = z.object({
 	 *
 	 * @default 0.228
 	 */
-	alphaDecay: z.number().min(0, "Alpha decay may not be negative").max(1, "Alpha decay may not be greater than 1").default(0.0228),
-}).partial()
+	alphaDecay: z.number().min(0, "Alpha decay may not be negative").max(1, "Alpha decay may not be greater than 1").default(DEFAULT_GRAPH_CONFIG.alphaDecay),
+}).partial();
 export type GraphConfig = z.infer<typeof graphConfigSchema>;
 
 export const globalGraphConfigSchema = graphConfigSchema.extend({

--- a/packages/starlight-site-graph/config/graph.ts
+++ b/packages/starlight-site-graph/config/graph.ts
@@ -490,7 +490,7 @@ export const graphConfigSchema = z.object({
 	 * @default 0.228
 	 */
 	alphaDecay: z.number().min(0, "Alpha decay may not be negative").max(1, "Alpha decay may not be greater than 1").default(DEFAULT_GRAPH_CONFIG.alphaDecay),
-}).partial();
+});
 export type GraphConfig = z.infer<typeof graphConfigSchema>;
 
 export const globalGraphConfigSchema = graphConfigSchema.extend({

--- a/packages/starlight-site-graph/config/index.ts
+++ b/packages/starlight-site-graph/config/index.ts
@@ -1,35 +1,37 @@
 import { AstroError } from 'astro/errors';
-import { type StarlightSiteGraphConfig, starlightSiteGraphConfig, starlightSiteGraphConfigSchema } from './base';
+import { starlightSiteGraphConfig, starlightSiteGraphConfigSchema } from './base';
 
 function isObject(item: unknown): item is Record<string, unknown> {
 	return (item !== null && typeof item === 'object' && !Array.isArray(item));
 }
 
-/**
- * NOTE: Adapted from https://stackoverflow.com/a/37164538/23278914
- */
-function deepMerge(target: unknown, source: unknown): unknown {
-	let output = Object.assign({}, target);
-	if (isObject(target) && isObject(source)) {
-		for (const [key, value] of Object.entries(source)) {
-			if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
-				continue;
-			}
+type DeepPartial<T> = {
+	[P in keyof T]?: T[P] extends Record<string, unknown>
+		? DeepPartial<T[P]> | undefined
+		: T[P] | undefined;
+};
 
-			if (isObject(value)) {
-				if (!(key in target))
-					Object.assign(output, { [key]: value });
-				else
-					output[key] = deepMerge(target[key], value);
-			} else {
-				Object.assign(output, { [key]: value });
-			}
+export function mergeDefaults<T extends Record<string, unknown>>(base: T, patch: DeepPartial<T>): T {
+	const result: Record<string, unknown> = { ...base };
+	for (const key of Object.keys(base)) {
+		if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+			continue;
+		}
+
+		const baseValue = result[key];
+		const patchValue = patch[key];
+
+		if (isObject(patchValue) && isObject(baseValue)) {
+			result[key] = mergeDefaults(baseValue, patchValue);
+		} else if (patchValue !== undefined) {
+			result[key] = patchValue;
 		}
 	}
-	return output;
+
+	return result as T;
 }
 
-export function validateConfig(userConfig: unknown) {
+export function validateConfig(baseConfig: typeof starlightSiteGraphConfig, userConfig: unknown) {
 	const config = starlightSiteGraphConfigSchema.safeParse(userConfig);
 
 	if (!config.success) {
@@ -45,9 +47,7 @@ export function validateConfig(userConfig: unknown) {
 		);
 	}
 
-	// TODO: Investigate how to apply Required<> to inferred type of schema, so comments still stay
-	// Merge with default settings
-	return deepMerge(starlightSiteGraphConfig, config.data) as typeof starlightSiteGraphConfig;
+	return mergeDefaults(baseConfig, config.data);
 }
 
 

--- a/packages/starlight-site-graph/config/index.ts
+++ b/packages/starlight-site-graph/config/index.ts
@@ -50,15 +50,6 @@ export function validateConfig(baseConfig: typeof starlightSiteGraphConfig, user
 	return mergeDefaults(baseConfig, config.data);
 }
 
-
-export type RemoveOptional<T> =
-	T extends (...args: any[]) => any ? T
-		: T extends object
-			? { [K in keyof T]-?: RemoveOptional<NonNullable<T[K]>> }
-			: T;
-
-
-export type FullStarlightSiteGraphConfig = RemoveOptional<StarlightSiteGraphConfig>;
 export { starlightSiteGraphConfig, starlightSiteGraphConfigSchema, type StarlightSiteGraphConfig } from './base';
 export { globalGraphConfig, graphConfigSchema, globalGraphConfigSchema, type GraphConfig } from './graph';
 export { type SitemapEntry, type Sitemap, globalSitemapConfig, globalSitemapConfigSchema, type SitemapConfig } from './sitemap';

--- a/packages/starlight-site-graph/config/index.ts
+++ b/packages/starlight-site-graph/config/index.ts
@@ -1,14 +1,14 @@
 import { AstroError } from 'astro/errors';
 import { type StarlightSiteGraphConfig, starlightSiteGraphConfig, starlightSiteGraphConfigSchema } from './base';
 
-function isObject(item: any): boolean {
-	return (item && typeof item === 'object' && !Array.isArray(item));
+function isObject(item: unknown): item is Record<string, unknown> {
+	return (item !== null && typeof item === 'object' && !Array.isArray(item));
 }
 
 /**
  * NOTE: Adapted from https://stackoverflow.com/a/37164538/23278914
  */
-function deepMerge(target: any, source: any): any {
+function deepMerge(target: unknown, source: unknown): unknown {
 	let output = Object.assign({}, target);
 	if (isObject(target) && isObject(source)) {
 		for (const [key, value] of Object.entries(source)) {

--- a/packages/starlight-site-graph/config/node.ts
+++ b/packages/starlight-site-graph/config/node.ts
@@ -1,30 +1,20 @@
 import { z } from 'astro/zod';
 
+const KWD_COLOR = [
+	'inherit',
+	'backgroundColor', 'nodeColor', 'nodeColorVisited', 'nodeColorCurrent', 'nodeColorUnresolved', 'nodeColorExternal', 'nodeColorTag',
+	'nodeColor1', 'nodeColor2', 'nodeColor3', 'nodeColor4', 'nodeColor5', 'nodeColor6', 'nodeColor7', 'nodeColor8', 'nodeColor9',
+	'linkColor',
+] as const;
+const KWD_NODE_SHAPE = ['circle', 'square', 'triangle', 'polygon', 'star'] as const;
+const KWD_NODE_CORNER_TYPE = ['normal', 'round', 'bevel'] as const;
+
 const validColors = z.union([
-	z.literal('inherit'),
-
-	z.literal('backgroundColor'),
-	z.literal('nodeColor'),
-	z.literal('nodeColorVisited'),
-	z.literal('nodeColorCurrent'),
-	z.literal('nodeColorUnresolved'),
-	z.literal('nodeColorExternal'),
-	z.literal('nodeColorTag'),
-
-	z.literal('nodeColor1'),
-	z.literal('nodeColor2'),
-	z.literal('nodeColor3'),
-	z.literal('nodeColor4'),
-	z.literal('nodeColor5'),
-	z.literal('nodeColor6'),
-	z.literal('nodeColor7'),
-	z.literal('nodeColor8'),
-	z.literal('nodeColor9'),
-	z.literal('linkColor'),
-]).or(
+	z.enum(KWD_COLOR),
 	z.string().refine(val => val.match(/^#([0-9A-Fa-f]{3}){1,2}$|^--?[_a-zA-Z]+[_a-zA-Z0-9-]*$/), {
 		message: 'Invalid color format, expected a hex color (e.g. #RRGGBB) or a CSS variable (e.g. --my-color)',
-	}));
+	})
+]);
 
 const percentageSchema = z.union([z.number().min(0, "Shape corner radius may not be negative"), z.string()
 	.refine(val => val.match(/^\d+\.?\d?\d?%?$/), {
@@ -35,32 +25,7 @@ const percentageSchema = z.union([z.number().min(0, "Shape corner radius may not
 	})]
 )
 
-const nodeShapeTypes = z.union([
-	/**
-	 * Circular shape
-	 */
-	z.literal('circle'),
-	/**
-	 * Square shape \
-	 * Defined as `polygon` with `shapePoints` set to 4
-	 */
-	z.literal('square'),
-	/**
-	 * Triangle shape \
-	 * Defined as `polygon` with `shapePoints` set to 3
-	 */
-	z.literal('triangle'),
-	/**
-	 * Regular polygon shape \
-	 * Defined by `shapePoints`
-	 */
-	z.literal('polygon'),
-	/**
-	 * Regular star 2n-polygon shape \
-	 * Defined by `shapePoints`
-	 */
-	z.literal('star'),
-]);
+const nodeShapeTypes = z.enum(KWD_NODE_SHAPE);
 export type NodeShapeType = z.infer<typeof nodeShapeTypes>;
 type NodeColorType = z.infer<typeof validColors>;
 
@@ -68,14 +33,14 @@ export const nodeStyleSchema = z.object({
 	/**
 	 * Shape of the node in the graph
 	 * - `circle`: Circular shape
-	 * - `square`: Square shape
-	 * - `triangle`: Triangle shape
-	 * - `polygon`: Polygon shape (with `shapePoints` vertices)
-	 * - `star`: Star shape (with `shapePoints` spikes)
+	 * - `square`: Square shape (`polygon` with `shapePoints` set to 4)
+	 * - `triangle`: Triangle shape (`polygon` with `shapePoints` set to 3)
+	 * - `polygon`: Regular polygon shape (with `shapePoints` vertices)
+	 * - `star`: Regular star 2n-polygon shape (with `shapePoints` spikes)
 	 *
 	 * @default "circle"
 	 */
-	shape: nodeShapeTypes.default('circle'),
+	shape: nodeShapeTypes.default('circle').optional(),
 	/**
 	 * Size of the node in the graph, further scaled by `linkScale`
 	 *
@@ -122,7 +87,7 @@ export const nodeStyleSchema = z.object({
 	 *
 	 * @optional
 	 */
-	cornerType: z.union([z.literal('normal'), z.literal('round'), z.literal('bevel')]).optional(),
+	cornerType: z.enum(KWD_NODE_CORNER_TYPE).optional(),
 
 	/**
 	 * Stroke width of the node in the graph

--- a/packages/starlight-site-graph/config/sitemap.ts
+++ b/packages/starlight-site-graph/config/sitemap.ts
@@ -188,6 +188,6 @@ export const globalSitemapConfigSchema = z.object({
 	styleRules: z.array(
 		z.tuple([z.array(z.string()), partialNodeStyleSchema])
 	).default([...DEFAULT_SITEMAP_CONFIG.styleRules])
-}).partial();
+});
 
 export type SitemapConfig = z.infer<typeof globalSitemapConfigSchema>;

--- a/packages/starlight-site-graph/config/sitemap.ts
+++ b/packages/starlight-site-graph/config/sitemap.ts
@@ -1,7 +1,7 @@
 import { z } from 'astro/zod';
 import { nodeStyleSchema } from './node';
 
-
+const partialNodeStyleSchema = nodeStyleSchema.partial();
 const sitemapEntrySchema = z.object({
 	/**
 	 * Whether the page is external (i.e. not part of the website)
@@ -38,26 +38,31 @@ const sitemapEntrySchema = z.object({
 	/**
 	 * The style of the node in the graph
 	 */
-	nodeStyle: nodeStyleSchema.partial().optional(),
+	nodeStyle: partialNodeStyleSchema.optional(),
 });
 
 export type SitemapEntry = z.infer<typeof sitemapEntrySchema>;
 const sitemapSchema = z.record(z.string(), sitemapEntrySchema);
 export type Sitemap = z.infer<typeof sitemapSchema>;
 
+const KWD_PAGE_TITLE_FALLBACK_STRATEGIES = ['linkText', 'slug'] as const;
+
+const DEFAULT_SITEMAP_CONFIG  = {
+	contentRoot: undefined as string | undefined,
+	includeExternalLinks: false,
+	sitemap: undefined as Sitemap | undefined,
+	pageTitles: {} as Record<string, string>,
+	ignoreLinksInSelectors: ['header', 'footer', 'nav', '.right-sidebar', '.site-title', '.slsg-backlinks'] as string[],
+	pageInclusionRules: ['**/*'] as string[],
+	pageTitleFallbackStrategy: 'linkText' as typeof KWD_PAGE_TITLE_FALLBACK_STRATEGIES[number],
+	linkInclusionRules: ['**/*'] as string[],
+	tagRules: {},
+	styleRules: [] as [string[], z.infer<typeof partialNodeStyleSchema>][]
+};
 
 export const globalSitemapConfig = {
-	contentRoot: undefined,
-	includeExternalLinks: false,
-	sitemap: undefined,
-	pageTitles: {},
-	ignoreLinksInSelectors: ['header', 'footer', 'nav', '.right-sidebar', '.site-title', '.slsg-backlinks'],
-	pageInclusionRules: ['**/*'],
-	pageTitleFallbackStrategy: 'linkText' as const,
-	linkInclusionRules: ['**/*'],
-	tagRules: {},
-	styleRules: [],
-}
+	...DEFAULT_SITEMAP_CONFIG,
+} satisfies SitemapConfig;
 
 export const globalSitemapConfigSchema = z.object({
 	/**
@@ -72,7 +77,7 @@ export const globalSitemapConfigSchema = z.object({
 	 *
 	 * @default false
 	 */
-	includeExternalLinks: z.boolean().default(globalSitemapConfig.includeExternalLinks),
+	includeExternalLinks: z.boolean().default(DEFAULT_SITEMAP_CONFIG.includeExternalLinks),
 
 	/**
 	 * Specify a custom sitemap to be used for the PageSidebar graph component.
@@ -91,14 +96,14 @@ export const globalSitemapConfigSchema = z.object({
 	 * @example The node with endpoint "BASEPATH/intro" should be called "Main" (instead of its frontmatter title "Introduction")
 	 * { "BASEPATH/intro": "Main" }
 	 */
-	pageTitles: z.record(z.string(), z.string()).default(globalSitemapConfig.pageTitles),
+	pageTitles: z.record(z.string(), z.string()).default(DEFAULT_SITEMAP_CONFIG.pageTitles),
 	/**
 	 * Determine what the name of a sitemap entry should be when no name was explicitly specified. \
 	 * This can be due to the page not having a title in the frontmatter, or the page being an external link.
 	 * - `linkText`: Use the most commonly used text associated with the link as the name of the page.
 	 * - `slug`: Use the last part of the link slug as the name of the page.
 	 */
-	pageTitleFallbackStrategy: z.enum(['linkText', 'slug']).default(globalSitemapConfig.pageTitleFallbackStrategy),
+	pageTitleFallbackStrategy: z.enum(KWD_PAGE_TITLE_FALLBACK_STRATEGIES).default(DEFAULT_SITEMAP_CONFIG.pageTitleFallbackStrategy),
 
 	/**
 	 * Ignore links parsed from HTML content where one of the element's ancestors matches one of the listed (simple) selectors.
@@ -115,7 +120,7 @@ export const globalSitemapConfigSchema = z.object({
 	 * @example Ignore all links with the 'external' class
 	 * [".external"]
 	 */
-	ignoreLinksInSelectors: z.array(z.string()).default(globalSitemapConfig.ignoreLinksInSelectors),
+	ignoreLinksInSelectors: z.array(z.string()).default([...DEFAULT_SITEMAP_CONFIG.ignoreLinksInSelectors]),
 
 	/**
 	 * Determine the inclusion of files in the sitemap based on provided ordered list of rules.
@@ -131,7 +136,7 @@ export const globalSitemapConfigSchema = z.object({
 	 * @example Include all Markdoc files except those in the "secret" folder:
 	 * ["!\/secret/**\/*.mdoc", "**\/*"]
 	 */
-	pageInclusionRules: z.array(z.string()).default(globalSitemapConfig.pageInclusionRules),
+	pageInclusionRules: z.array(z.string()).default([...DEFAULT_SITEMAP_CONFIG.pageInclusionRules]),
 
 	/**
 	 * Determine which links are included in the sitemap for every page.
@@ -149,7 +154,7 @@ export const globalSitemapConfigSchema = z.object({
 	 * @example Remove external links to GitHub for "Edit page":
 	 * ["!https://**\/edit/**", "**\/*"]
 	 */
-	linkInclusionRules: z.array(z.string()).default(globalSitemapConfig.linkInclusionRules),
+	linkInclusionRules: z.array(z.string()).default([...DEFAULT_SITEMAP_CONFIG.linkInclusionRules]),
 
 	/**
 	 * Determine which pages should be associated with specific tags based on provided ordered list of rules. \
@@ -164,7 +169,7 @@ export const globalSitemapConfigSchema = z.object({
 	 * @example Add the "secret" tag to all pages except those in the "public" folder, will remove existing "secret" tags in the "public" folder:
 	 * { "secret": ["!public/**", "**\/*"] }
 	 */
-	tagRules: z.record(z.string(), z.array(z.string())).default(globalSitemapConfig.tagRules),
+	tagRules: z.record(z.string(), z.array(z.string())).default({ ...DEFAULT_SITEMAP_CONFIG.tagRules }),
 
 	/**
 	 * Specify styles to be applied to pages based on provided ordered list of rules. \
@@ -181,8 +186,8 @@ export const globalSitemapConfigSchema = z.object({
 	 * [ [["!\/public/**", "**\/*"], { nodeScale: 2, strokeWidth: "2", shapeColor: "backgroundColor" }] ]
 	 */
 	styleRules: z.array(
-		z.tuple([z.array(z.string()), nodeStyleSchema.partial()])
-	).default(globalSitemapConfig.styleRules)
+		z.tuple([z.array(z.string()), partialNodeStyleSchema])
+	).default([...DEFAULT_SITEMAP_CONFIG.styleRules])
 }).partial();
 
 export type SitemapConfig = z.infer<typeof globalSitemapConfigSchema>;

--- a/packages/starlight-site-graph/index.ts
+++ b/packages/starlight-site-graph/index.ts
@@ -1,11 +1,11 @@
 import type { StarlightPlugin } from '@astrojs/starlight/types';
-import { validateConfig, type StarlightSiteGraphConfig } from './config';
+import { validateConfig, type StarlightSiteGraphConfig, starlightSiteGraphConfig } from './config';
 
 import integration from './integration';
 import { translations } from './i18n';
 
 export default function plugin(userConfig?: StarlightSiteGraphConfig): StarlightPlugin {
-	const parsedConfig = validateConfig(userConfig);
+	const parsedConfig = validateConfig(starlightSiteGraphConfig, userConfig);
 	return {
 		name: 'starlight-site-graph-plugin',
 		hooks: {

--- a/packages/starlight-site-graph/index.ts
+++ b/packages/starlight-site-graph/index.ts
@@ -12,7 +12,7 @@ export default function plugin(userConfig?: StarlightSiteGraphConfig): Starlight
 			'i18n:setup'({ injectTranslations }) {
 				injectTranslations(translations);
 			},
-			'config:setup': async ({ addIntegration, config, astroConfig, command, logger, updateConfig }) => {
+			'config:setup': async ({ addIntegration, config, command, logger, updateConfig }) => {
 				if (command === 'preview') return;
 
 				// TODO: Temporary implementation of graph/backlinks exclusion from plugin

--- a/packages/starlight-site-graph/integration.ts
+++ b/packages/starlight-site-graph/integration.ts
@@ -5,7 +5,7 @@ import { addVirtualImports, defineIntegration } from 'astro-integration-kit';
 
 import { fileURLToPath } from 'node:url';
 
-import { starlightSiteGraphConfigSchema, type FullStarlightSiteGraphConfig, validateConfig } from './config';
+import { starlightSiteGraphConfig, starlightSiteGraphConfigSchema, validateConfig } from './config';
 import { SiteMapBuilder } from './sitemap/build';
 import { processSitemap } from './sitemap/process';
 import { trimSlashes } from './sitemap/util';
@@ -85,6 +85,7 @@ export default defineIntegration({
 													return code.replace(/process\.platform/g, '"undefined"');
 												}
 											}
+											return null;
 										}
 									}
 								],
@@ -134,7 +135,7 @@ export default defineIntegration({
 						outputPath = fileURLToPath(config.outDir);
 					}
 
-					if (!sitemapProvided) {
+					if (settings.sitemapConfig.sitemap === undefined) {
 						log(logger, "info",
 							'Retrieving links from Markdown content' +
 							(settings.sitemapConfig.pageInclusionRules.length

--- a/packages/starlight-site-graph/integration.ts
+++ b/packages/starlight-site-graph/integration.ts
@@ -252,11 +252,13 @@ export default defineIntegration({
 					injectTypes({
 						filename: "types.d.ts",
 						content: `declare module 'virtual:starlight-site-graph/config' {
-							export default ${JSON.stringify(settings)};
+							const Config: import('./packages/starlight-site-graph/config').FullStarlightSiteGraphConfig;
+							export default Config;
 						}
-						
+
 						declare module 'virtual:starlight-site-graph/astro-config' {
-							export default ${JSON.stringify(args.config)};
+							const Config: import('astro').AstroConfig;
+							export default Config;
 						}`
 					});
 				},

--- a/packages/starlight-site-graph/integration.ts
+++ b/packages/starlight-site-graph/integration.ts
@@ -112,7 +112,6 @@ export default defineIntegration({
 					}
 
 					const addTrailingSlash = config.trailingSlash !== 'never';
-					builder.setContentRoot(settings.sitemapConfig.contentRoot);
 					builder.setTrailingSlash(addTrailingSlash);
 
 					// TODO: Figure if it is somehow possible to conditionally import astro:prefetch without triggering vite errors
@@ -163,7 +162,7 @@ export default defineIntegration({
 							// Only attempt to add content if directory exists
 							if (!sitemapGenerationFailed) {
 								try {
-									await builder.addMDContentFolder(settings.sitemapConfig.contentRoot, settings.sitemapConfig.pageInclusionRules)
+									await builder.addMDContentFolder(trimSlashes(settings.sitemapConfig.contentRoot), settings.sitemapConfig.pageInclusionRules)
 									settings.sitemapConfig.sitemap = builder.process().toSitemap();
 									log(logger, "info", 'Successfully generated sitemap from Markdown content');
 								} catch (e) {

--- a/packages/starlight-site-graph/integration.ts
+++ b/packages/starlight-site-graph/integration.ts
@@ -43,9 +43,11 @@ export default defineIntegration({
 	optionsSchema: starlightSiteGraphConfigSchema,
 	setup({ name, options }) {
 		if (!options.starlight) {
-			options = { starlight: false, ...validateConfig(options) };
+			// EXPL: This codepath is hit if the integration was called directly, without going through the Starlight plugin.
+			// 		 The flag is currently only used to identify what default contentRoot to use
+			options = { ...validateConfig(starlightSiteGraphConfig, options), starlight: false };
 		}
-		let settings = options as FullStarlightSiteGraphConfig;
+		let settings = options as typeof starlightSiteGraphConfig;
 
 		const builder = new SiteMapBuilder(settings.sitemapConfig);
 		const sitemapProvided = !!settings.sitemapConfig.sitemap;

--- a/packages/starlight-site-graph/sitemap/build.ts
+++ b/packages/starlight-site-graph/sitemap/build.ts
@@ -27,7 +27,6 @@ interface IntermediateSitemapEntry {
 
 export class SiteMapBuilder {
 	private map: Map<string, IntermediateSitemapEntry>;
-	private contentRoot: string | undefined;
 	private excludedPaths: Set<string> = new Set();
 	private addTrailingSlash: boolean = false;
 	private encounteredFiles: Set<string> = new Set();
@@ -43,11 +42,6 @@ export class SiteMapBuilder {
 		this.explicitNameAssociations = new Map(
 			Object.entries(this.config.pageTitles).map(([k, v]) => [setSlashes(k, true, this.addTrailingSlash), v]),
 		);
-	}
-
-	setContentRoot(contentRoot: string) {
-		this.contentRoot = trimSlashes(contentRoot);
-		return this;
 	}
 
 	setBasePath(basePath: string) {
@@ -156,14 +150,14 @@ export class SiteMapBuilder {
 			if (path.extname(filePath) === '.md' || path.extname(filePath) === '.mdx' || path.extname(filePath) === '.mdoc') {
 				const relativePath = ensureLeadingSlash(path.relative(folder, filePath).replace(/\\/g, '/'));
 				if (firstMatchingPattern(relativePath, patterns, false)) {
-					await this.addMDContent(filePath);
+					await this.addMDContent(filePath, folder);
 				}
 			}
 		}
 		return this;
 	}
 
-	async addMDContent(filePath: string) {
+	async addMDContent(filePath: string, folderPath: string) {
 		const content = await fs.promises.readFile(filePath, 'utf8');
 		const frontmatter = matter(content) as unknown as { data: PageSiteGraphFrontmatter & { slug?: string } };
 
@@ -179,7 +173,7 @@ export class SiteMapBuilder {
 		}
 		// Otherwise, re-create the Astro slug from the file path
 		else {
-			linkPath = setSlashes(this.getLinkPath(filePath, this.contentRoot, this.basePath), true, this.addTrailingSlash);
+			linkPath = setSlashes(this.getLinkPath(filePath, folderPath, this.basePath), true, this.addTrailingSlash);
 		}
 
 		this.encounteredFiles.add(linkPath);

--- a/packages/starlight-site-graph/sitemap/build.ts
+++ b/packages/starlight-site-graph/sitemap/build.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import matter from 'gray-matter';
 
 import type { PageSiteGraphFrontmatter } from '../schema';
-import type { NodeStyle, RemoveOptional, Sitemap, SitemapConfig } from '../config';
+import type { NodeStyle, Sitemap, SitemapConfig } from '../config';
 
 import {
 	ensureLeadingPound, trimSlashes, setSlashes,
@@ -38,7 +38,7 @@ export class SiteMapBuilder {
 	explicitNameAssociations: Map<string, string> = new Map();
 	frontmatterData: Map<string, { data?: PageSiteGraphFrontmatter } & { slug?: string }> = new Map();
 
-	constructor(private config: RemoveOptional<SitemapConfig>) {
+	constructor(private config: SitemapConfig) {
 		this.map = new Map();
 		this.explicitNameAssociations = new Map(
 			Object.entries(this.config.pageTitles).map(([k, v]) => [setSlashes(k, true, this.addTrailingSlash), v]),

--- a/packages/starlight-site-graph/sitemap/process.ts
+++ b/packages/starlight-site-graph/sitemap/process.ts
@@ -1,38 +1,39 @@
 import { ensureLeadingPound, firstMatchingPattern } from './util';
-import type { FullStarlightSiteGraphConfig, NodeStyle, RemoveOptional, Sitemap } from '../config';
+import type { StarlightSiteGraphConfig, NodeStyle, Sitemap } from '../config';
 
 /**
  * Ensure that the passed sitemap is valid and has all rules applied to it
  */
-export function processSitemap(sitemap: RemoveOptional<Sitemap>, options: FullStarlightSiteGraphConfig) {
-	for (const [linkPath, entry] of Object.entries(sitemap)) {
-		const tags = new Set<string>(entry.tags);
-		for (const [tag, tagRules] of Object.entries(options.sitemapConfig.tagRules)) {
-			const ruleResult = firstMatchingPattern(linkPath, tagRules);
-			if (ruleResult) {
-				tags.add(tag);
-			} else if (ruleResult !== undefined) {
-				tags.delete(tag);
+export function processSitemap(sitemap: Sitemap, options: StarlightSiteGraphConfig) {
+	if (options.sitemapConfig) {
+		for (const [linkPath, entry] of Object.entries(sitemap)) {
+			const tags = new Set<string>(entry.tags);
+			for (const [tag, tagRules] of Object.entries(options.sitemapConfig.tagRules ?? [])) {
+				const ruleResult = firstMatchingPattern(linkPath, tagRules);
+				if (ruleResult) {
+					tags.add(tag);
+				} else if (ruleResult !== undefined) {
+					tags.delete(tag);
+				}
 			}
-		}
-		entry.tags = [...tags].map(ensureLeadingPound);
+			entry.tags = [...tags].map(ensureLeadingPound);
 
-		let nodeStyle = {} as Partial<NodeStyle>;
-		for (const [rules, style] of options.sitemapConfig.styleRules ?? []) {
-			const ruleResult = firstMatchingPattern(linkPath, rules);
-			if (ruleResult) {
-				nodeStyle = {
-					...(style as NodeStyle),
-					...nodeStyle,
-				};
+			let nodeStyle = {} as Partial<NodeStyle>;
+			for (const [rules, style] of options.sitemapConfig.styleRules ?? []) {
+				const ruleResult = firstMatchingPattern(linkPath, rules);
+				if (ruleResult) {
+					nodeStyle = {
+						...(style as NodeStyle),
+						...nodeStyle,
+					};
+				}
 			}
-		}
 
-		// @ts-expect-error shapeColor cannot be correctly casted
-		entry.nodeStyle = {
-			...entry.nodeStyle,
-			...nodeStyle,
-		};
+			entry.nodeStyle = {
+				...entry.nodeStyle,
+				...nodeStyle,
+			};
+		}
 	}
 
 	return sitemap;

--- a/packages/starlight-site-graph/virtual.d.ts
+++ b/packages/starlight-site-graph/virtual.d.ts
@@ -1,9 +1,9 @@
 declare module 'virtual:starlight-site-graph/config' {
-	const Config: import('./config').StarlightSiteGraphConfig;
+	const Config: import('./config').FullStarlightSiteGraphConfig;
 	export default Config;
 }
 
 declare module 'virtual:starlight-site-graph/astro-config' {
-	const Config: import('./node_modules/astro/dist/@types/astro.js').AstroConfig;
+	const Config: import('astro').AstroConfig;
 	export default Config;
 }

--- a/packages/starlight-site-graph/virtual.d.ts
+++ b/packages/starlight-site-graph/virtual.d.ts
@@ -1,5 +1,5 @@
 declare module 'virtual:starlight-site-graph/config' {
-	const Config: import('./config').FullStarlightSiteGraphConfig;
+	const Config: import('./config').StarlightSiteGraphConfig;
 	export default Config;
 }
 


### PR DESCRIPTION
Replaced a bunch of `any` types with proper typing:

- deepMerge/deepDiff now use unknown + type guards
- Virtual module generation references TS types instead of JSON.stringify
- D3 force simulation has proper generics
- Added DiffResult/DiffValue types

Makes the IDE happier and catches more bugs at compile time.